### PR TITLE
Fix: Allow access to the click event from toastAction fn

### DIFF
--- a/js/nativedroid2.js
+++ b/js/nativedroid2.js
@@ -391,9 +391,9 @@
                     var hasLink = (_self.options.action.link);
                     var hasEvent = (_self.options.action.fn && typeof _self.options.action.fn === "function");
 
-                    toast.find(".nd2-toast-action a").on("click", function() {
+                    toast.find(".nd2-toast-action a").on("click", function(e) {
                         if (hasEvent) {
-                            _self.options.action.fn();
+                            _self.options.action.fn(e);
                         }
                         if (hasLink) {
                             $("body").pagecontainer("change", _self.options.action.link);


### PR DESCRIPTION
In our SPA application, changing the URL hash triggers routing to another page.
Clicking the action button in the Toast popup while fn is defined, will set the URL hash to "#toastAction".
It's possible that other projects depend on this feature, but it should be easily overridable.

It should be possible to do the following:
```
new $.nd2Toast({
   message : "Sample Message",
   action : {
     title : "Pick phone",
     fn : function(e) {
        e.preventDefault()
        // Handle the event here
     }
   }
});
```