### PR TITLE
Fix: Fix nd2tabs not showing up when re-rendering

### DIFF
--- a/js/nativedroid2.js
+++ b/js/nativedroid2.js
@@ -303,7 +303,7 @@
         }
     });
 
-    $(document).bind("pagecreate", function(e) {
+    $(document).bind("pagebeforeshow", function(e) {
         $(document).trigger("includebeforecreate");
         return $("[data-role='nd2tabs']", e.target).tabs();
     });


### PR DESCRIPTION
In our webapp, we often re-render a template which contains the tab element. It only worked during first render, as pagecreate is only triggered once. Re-rendering triggers pagebeforeshow event.

Some other elements also use the same event. Don't know how/why they are used, changing pagecreate to pagebeforeshow may also be a good idea there.
